### PR TITLE
chore(deps): upgrade grumbler-scripts to version 8.0.1

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 module.exports = {
-    'extends': './node_modules/@krakenjs/grumbler-scripts/config/.eslintrc-browser.js',
+    'extends': './node_modules/@krakenjs/eslint-config-grumbler/eslintrc-browser.js',
 
     globals: {
         __STAGE__: true,

--- a/package.json
+++ b/package.json
@@ -47,17 +47,20 @@
   "license": "Apache-2.0",
   "readmeFilename": "README.md",
   "dependencies": {
-    "@paypal/sdk-client": "^4.0.166",
-    "@paypal/sdk-constants": "^1.0.127",
     "@krakenjs/belter": "^2.0.0",
-    "@krakenjs/cross-domain-utils": "^3.0.0"
+    "@krakenjs/cross-domain-utils": "^3.0.0",
+    "@paypal/sdk-client": "^4.0.166",
+    "@paypal/sdk-constants": "^1.0.127"
   },
   "devDependencies": {
-    "@krakenjs/grumbler-scripts": "^7.0.0",
+    "@krakenjs/grumbler-scripts": "^8.0.1",
     "@krakenjs/sync-browser-mocks": "^3.0.0",
     "babel-core": "^7.0.0-bridge.0",
     "cheerio": "^1.0.0-rc.3",
+    "cross-env": "^7.0.3",
     "flow-bin": "0.155.0",
+    "flow-typed": "^3.8.0",
+    "jest": "^29.2.2",
     "mocha": "^4"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 /* @flow */
 /* eslint import/no-nodejs-modules: off */
 
-import type { WebpackConfig } from '@krakenjs/grumbler-scripts/config/types';
+import type { WebpackConfig } from '@krakenjs/webpack-config-grumbler/index.flow';
 import { getWebpackConfig } from '@krakenjs/grumbler-scripts/config/webpack.config';
 
 import { testGlobals } from './test/client/test-globals';


### PR DESCRIPTION
Upgrading to the latest and greatest grumbler-scripts. One new change is we need to explicitly include `flow-typed`, `jest`, and `cross-env` in our devDependencies.